### PR TITLE
Update route and route-test blueprints

### DIFF
--- a/blueprints/route-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/route-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('<%= friendlyTestDescription %>', function() {
+  setupTest();
+
+  it('exists', function() {
+    let route = this.owner.lookup('route:<%= dasherizedModuleName %>');
+    expect(route).to.be.ok;
+  });
+});

--- a/node-tests/blueprints/route-addon-test.js
+++ b/node-tests/blueprints/route-addon-test.js
@@ -18,11 +18,13 @@ describe('Blueprint: route-addon', function() {
 
     it('route-addon foo', function() {
       return emberGenerateDestroy(['route-addon', 'foo'], _file => {
-        expect(_file('app/routes/foo.ts'))
-          .to.contain("export { default } from 'my-addon/routes/foo';");
+        expect(_file('app/routes/foo.ts')).to.contain(
+          "export { default } from 'my-addon/routes/foo';"
+        );
 
-        expect(_file('app/templates/foo.ts'))
-          .to.contain("export { default } from 'my-addon/templates/foo';");
+        expect(_file('app/templates/foo.ts')).to.contain(
+          "export { default } from 'my-addon/templates/foo';"
+        );
       });
     });
   });

--- a/node-tests/blueprints/route-test-test.js
+++ b/node-tests/blueprints/route-test-test.js
@@ -17,12 +17,18 @@ describe('Blueprint: route-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
+      return emberNew();
     });
 
-    it('route-test foo', function() {
-      return emberGenerateDestroy(['route-test', 'foo'], _file => {
-        expect(_file('tests/unit/routes/foo-test.ts')).to.equal(fixture('route-test/default.ts'));
+    describe('with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
+
+      it('route-test foo', function() {
+        return emberGenerateDestroy(['route-test', 'foo'], _file => {
+          expect(_file('tests/unit/routes/foo-test.ts')).to.equal(fixture('route-test/default.ts'));
+        });
       });
     });
 
@@ -67,6 +73,24 @@ describe('Blueprint: route-test', function() {
         return emberGenerateDestroy(['route-test', 'foo'], _file => {
           expect(_file('tests/unit/routes/foo-test.ts')).to.equal(
             fixture('route-test/mocha-0.12.ts')
+          );
+        });
+      });
+    });
+
+    describe('with ember-mocha@0.14.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('route-test foo', function() {
+        return emberGenerateDestroy(['route-test', 'foo'], _file => {
+          expect(_file('tests/unit/routes/foo-test.ts')).to.equal(
+            fixture('route-test/mocha-rfc232.ts')
           );
         });
       });

--- a/node-tests/blueprints/route-test.js
+++ b/node-tests/blueprints/route-test.js
@@ -8,13 +8,14 @@ const emberDestroy = blueprintHelpers.emberDestroy;
 const emberGenerateDestroy = blueprintHelpers.emberGenerateDestroy;
 const setupPodConfig = blueprintHelpers.setupPodConfig;
 
-const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
-
 const expectError = require('../helpers/expect-error');
 const chai = require('ember-cli-blueprint-test-helpers/chai');
 const expect = chai.expect;
 const file = chai.file;
 const fs = require('fs-extra');
+
+const generateFakePackageManifest = require('../helpers/generate-fake-package-manifest');
+const fixture = require('../helpers/fixture');
 
 describe('Blueprint: route', function() {
   setupTestHooks(this);
@@ -26,19 +27,11 @@ describe('Blueprint: route', function() {
 
     it('route foo', function() {
       return emberGenerateDestroy(['route', 'foo'], _file => {
-        expect(_file('app/routes/foo.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('app/routes/foo.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('app/templates/foo.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('tests/unit/routes/foo-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('tests/unit/routes/foo-test.ts')).to.equal(fixture('route-test/default.ts'));
 
         expect(file('app/router.js')).to.contain("this.route('foo')");
       }).then(() => {
@@ -59,19 +52,11 @@ describe('Blueprint: route', function() {
 
     it('route foo --path=:foo_id/show', function() {
       return emberGenerateDestroy(['route', 'foo', '--path=:foo_id/show'], _file => {
-        expect(_file('app/routes/foo.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('app/routes/foo.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('app/templates/foo.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('tests/unit/routes/foo-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('tests/unit/routes/foo-test.ts')).to.equal(fixture('route-test/default.ts'));
 
         expect(file('app/router.js'))
           .to.contain("this.route('foo', {")
@@ -86,19 +71,13 @@ describe('Blueprint: route', function() {
 
     it('route parent/child --reset-namespace', function() {
       return emberGenerateDestroy(['route', 'parent/child', '--reset-namespace'], _file => {
-        expect(_file('app/routes/child.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class ParentChild extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('app/routes/child.ts')).to.equal(fixture('route/route-child.ts'));
 
         expect(_file('app/templates/child.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('tests/unit/routes/child-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:child'");
+        expect(_file('tests/unit/routes/child-test.ts')).to.equal(
+          fixture('route-test/default-child.ts')
+        );
 
         expect(file('app/router.js'))
           .to.contain("this.route('parent', {")
@@ -112,19 +91,13 @@ describe('Blueprint: route', function() {
       return emberGenerateDestroy(
         ['route', 'parent/child', '--reset-namespace', '--pod'],
         _file => {
-          expect(_file('app/child/route.ts'))
-            .to.contain("import Route from '@ember/routing/route';")
-            .to.contain('export default class ParentChild extends Route.extend({')
-            .to.contain('  // anything which *must* be merged to prototype here')
-            .to.contain('}) {')
-            .to.contain('  // normal class body definition here')
-            .to.contain('}');
+          expect(_file('app/child/route.ts')).to.equal(fixture('route/route-child.ts'));
 
           expect(_file('app/child/template.hbs')).to.equal('{{outlet}}');
 
-          expect(_file('tests/unit/child/route-test.ts'))
-            .to.contain("import { moduleFor, test } from 'ember-qunit';")
-            .to.contain("moduleFor('route:child'");
+          expect(_file('tests/unit/child/route-test.ts')).to.equal(
+            fixture('route-test/default-child.ts')
+          );
 
           expect(file('app/router.js'))
             .to.contain("this.route('parent', {")
@@ -164,19 +137,11 @@ describe('Blueprint: route', function() {
 
     it('route foo --pod', function() {
       return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
-        expect(_file('app/foo/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('app/foo/route.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('app/foo/template.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('tests/unit/foo/route-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('tests/unit/foo/route-test.ts')).to.equal(fixture('route-test/default.ts'));
 
         expect(file('app/router.js')).to.contain("this.route('foo')");
       }).then(() => {
@@ -228,19 +193,13 @@ describe('Blueprint: route', function() {
 
       it('route foo --pod', function() {
         return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
-          expect(_file('app/pods/foo/route.ts'))
-            .to.contain("import Route from '@ember/routing/route';")
-            .to.contain('export default class Foo extends Route.extend({')
-            .to.contain('  // anything which *must* be merged to prototype here')
-            .to.contain('}) {')
-            .to.contain('  // normal class body definition here')
-            .to.contain('}');
+          expect(_file('app/pods/foo/route.ts')).to.equal(fixture('route/route.ts'));
 
           expect(_file('app/pods/foo/template.hbs')).to.equal('{{outlet}}');
 
-          expect(_file('tests/unit/pods/foo/route-test.ts'))
-            .to.contain("import { moduleFor, test } from 'ember-qunit';")
-            .to.contain("moduleFor('route:foo'");
+          expect(_file('tests/unit/pods/foo/route-test.ts')).to.equal(
+            fixture('route-test/default.ts')
+          );
 
           expect(file('app/router.js')).to.contain("this.route('foo')");
         }).then(() => {
@@ -252,20 +211,14 @@ describe('Blueprint: route', function() {
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
+      return emberNew({ target: 'addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
-    // Skipping these because the reason they're failing is *not* apparent, and
-    // this is a pretty corner case scenario.
-    it.skip('route foo', function() {
+    it('route foo', function() {
       return emberGenerateDestroy(['route', 'foo'], _file => {
-        expect(_file('addon/routes/foo.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('addon/routes/foo.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('addon/templates/foo.hbs')).to.equal('{{outlet}}');
 
@@ -277,9 +230,7 @@ describe('Blueprint: route', function() {
           "export { default } from 'my-addon/templates/foo';"
         );
 
-        expect(_file('tests/unit/routes/foo-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('tests/unit/routes/foo-test.ts')).to.equal(fixture('route-test/default.ts'));
 
         expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('foo')");
       }).then(() => {
@@ -287,17 +238,9 @@ describe('Blueprint: route', function() {
       });
     });
 
-    // Skipping these because the reason they're failing is *not* apparent, and
-    // this is a pretty corner case scenario.
-    it.skip('route foo/bar', function() {
+    it('route foo/bar', function() {
       return emberGenerateDestroy(['route', 'foo/bar'], _file => {
-        expect(_file('addon/routes/foo/bar.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class FooBar extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('addon/routes/foo/bar.ts')).to.equal(fixture('route/route-nested.ts'));
 
         expect(_file('addon/templates/foo/bar.hbs')).to.equal('{{outlet}}');
 
@@ -309,9 +252,9 @@ describe('Blueprint: route', function() {
           "export { default } from 'my-addon/templates/foo/bar';"
         );
 
-        expect(_file('tests/unit/routes/foo/bar-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo/bar'");
+        expect(_file('tests/unit/routes/foo/bar-test.ts')).to.equal(
+          fixture('route-test/default-nested.ts')
+        );
 
         expect(file('tests/dummy/app/router.js')).to.not.contain("this.route('bar')");
       }).then(() => {
@@ -321,13 +264,7 @@ describe('Blueprint: route', function() {
 
     it('route foo --dummy', function() {
       return emberGenerateDestroy(['route', 'foo', '--dummy'], _file => {
-        expect(_file('tests/dummy/app/routes/foo.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('tests/dummy/app/routes/foo.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('tests/dummy/app/templates/foo.hbs')).to.equal('{{outlet}}');
 
@@ -343,13 +280,9 @@ describe('Blueprint: route', function() {
 
     it('route foo/bar --dummy', function() {
       return emberGenerateDestroy(['route', 'foo/bar', '--dummy'], _file => {
-        expect(_file('tests/dummy/app/routes/foo/bar.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class FooBar extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('tests/dummy/app/routes/foo/bar.ts')).to.equal(
+          fixture('route/route-nested.ts')
+        );
 
         expect(_file('tests/dummy/app/templates/foo/bar.hbs')).to.equal('{{outlet}}');
 
@@ -365,17 +298,9 @@ describe('Blueprint: route', function() {
       });
     });
 
-    // Skipping these because the reason they're failing is *not* apparent, and
-    // this is a pretty corner case scenario.
-    it.skip('route foo --pod', function() {
+    it('route foo --pod', function() {
       return emberGenerateDestroy(['route', 'foo', '--pod'], _file => {
-        expect(_file('addon/foo/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('addon/foo/route.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('addon/foo/template.hbs')).to.equal('{{outlet}}');
 
@@ -387,9 +312,7 @@ describe('Blueprint: route', function() {
           "export { default } from 'my-addon/foo/template';"
         );
 
-        expect(_file('tests/unit/foo/route-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('tests/unit/foo/route-test.ts')).to.equal(fixture('route-test/default.ts'));
       });
     });
   });
@@ -397,28 +320,20 @@ describe('Blueprint: route', function() {
   describe('in app - module unification', function() {
     beforeEach(function() {
       return emberNew()
-        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'))
         .then(() => {
           fs.ensureDirSync('src');
           fs.writeFileSync('src/router.js', fs.readFileSync('app/router.js'));
-        });
+        })
+        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('route foo', function() {
       return emberGenerateDestroy(['route', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('src/ui/routes/foo/route.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/route-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('src/ui/routes/foo/route-test.ts')).to.equal(fixture('route-test/default.ts'));
 
         expect(file('src/router.js')).to.contain("this.route('foo')");
       }).then(() => {
@@ -439,19 +354,11 @@ describe('Blueprint: route', function() {
 
     it('route foo --path=:foo_id/show', function() {
       return emberGenerateDestroy(['route', 'foo', '--path=:foo_id/show'], _file => {
-        expect(_file('src/ui/routes/foo/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('src/ui/routes/foo/route.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/route-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('src/ui/routes/foo/route-test.ts')).to.equal(fixture('route-test/default.ts'));
 
         expect(file('src/router.js'))
           .to.contain("this.route('foo', {")
@@ -466,19 +373,15 @@ describe('Blueprint: route', function() {
 
     it('route parent/child --reset-namespace', function() {
       return emberGenerateDestroy(['route', 'parent/child', '--reset-namespace'], _file => {
-        expect(_file('src/ui/routes/parent/child/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class ParentChild extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('src/ui/routes/parent/child/route.ts')).to.equal(
+          fixture('route/route-child.ts')
+        );
 
         expect(_file('src/ui/routes/parent/child/template.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/parent/child/route-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:child'");
+        expect(_file('src/ui/routes/parent/child/route-test.ts')).to.equal(
+          fixture('route-test/default-child.ts')
+        );
 
         expect(file('src/router.js'))
           .to.contain("this.route('parent', {")
@@ -575,29 +478,24 @@ describe('Blueprint: route', function() {
   describe('in addon - module unification', function() {
     beforeEach(function() {
       return emberNew({ target: 'addon' })
-        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'))
         .then(() => {
           fs.ensureDirSync('src');
           fs.ensureDirSync('tests/dummy/src');
-          fs.writeFileSync('tests/dummy/src/router.js', fs.readFileSync('tests/dummy/app/router.js'));
-        });
+          fs.writeFileSync(
+            'tests/dummy/src/router.js',
+            fs.readFileSync('tests/dummy/app/router.js')
+          );
+        })
+        .then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
     });
 
     it('route foo', function() {
       return emberGenerateDestroy(['route', 'foo'], _file => {
-        expect(_file('src/ui/routes/foo/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('src/ui/routes/foo/route.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/route-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('src/ui/routes/foo/route-test.ts')).to.equal(fixture('route-test/default.ts'));
 
         expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('foo')");
       }).then(() => {
@@ -607,19 +505,13 @@ describe('Blueprint: route', function() {
 
     it('route foo/bar', function() {
       return emberGenerateDestroy(['route', 'foo/bar'], _file => {
-        expect(_file('src/ui/routes/foo/bar/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class FooBar extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('src/ui/routes/foo/bar/route.ts')).to.equal(fixture('route/route-nested.ts'));
 
         expect(_file('src/ui/routes/foo/bar/template.hbs')).to.equal('{{outlet}}');
 
-        expect(_file('src/ui/routes/foo/bar/route-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo/bar'");
+        expect(_file('src/ui/routes/foo/bar/route-test.ts')).to.equal(
+          fixture('route-test/default-nested.ts')
+        );
 
         expect(file('tests/dummy/src/router.js')).to.not.contain("this.route('bar')");
       }).then(() => {
@@ -629,13 +521,7 @@ describe('Blueprint: route', function() {
 
     it('route foo --dummy', function() {
       return emberGenerateDestroy(['route', 'foo', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/routes/foo/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('tests/dummy/src/ui/routes/foo/route.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('tests/dummy/src/ui/routes/foo/template.hbs')).to.equal('{{outlet}}');
 
@@ -651,13 +537,9 @@ describe('Blueprint: route', function() {
 
     it('route foo/bar --dummy', function() {
       return emberGenerateDestroy(['route', 'foo/bar', '--dummy'], _file => {
-        expect(_file('tests/dummy/src/ui/routes/foo/bar/route.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class FooBar extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('tests/dummy/src/ui/routes/foo/bar/route.ts')).to.equal(
+          fixture('route/route-nested.ts')
+        );
 
         expect(_file('tests/dummy/src/ui/routes/foo/bar/template.hbs')).to.equal('{{outlet}}');
 
@@ -681,22 +563,16 @@ describe('Blueprint: route', function() {
     });
   });
 
-  // Skipping these because the reason they're failing is *not* apparent, and
-  // this is a pretty corner case scenario.
-  describe.skip('in in-repo-addon', function() {
+  describe('in in-repo-addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'in-repo-addon' });
+      return emberNew({ target: 'in-repo-addon' }).then(() =>
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
+      );
     });
 
     it('route foo --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['route', 'foo', '--in-repo-addon=my-addon'], _file => {
-        expect(_file('lib/my-addon/addon/routes/foo.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class Foo extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('lib/my-addon/addon/routes/foo.ts')).to.equal(fixture('route/route.ts'));
 
         expect(_file('lib/my-addon/addon/templates/foo.hbs')).to.equal('{{outlet}}');
 
@@ -708,21 +584,15 @@ describe('Blueprint: route', function() {
           "export { default } from 'my-addon/templates/foo';"
         );
 
-        expect(_file('tests/unit/routes/foo-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo'");
+        expect(_file('tests/unit/routes/foo-test.ts')).to.equal(fixture('route-test/default.ts'));
       });
     });
 
     it('route foo/bar --in-repo-addon=my-addon', function() {
       return emberGenerateDestroy(['route', 'foo/bar', '--in-repo-addon=my-addon'], _file => {
-        expect(_file('lib/my-addon/addon/routes/foo/bar.ts'))
-          .to.contain("import Route from '@ember/routing/route';")
-          .to.contain('export default class FooBar extends Route.extend({')
-          .to.contain('  // anything which *must* be merged to prototype here')
-          .to.contain('}) {')
-          .to.contain('  // normal class body definition here')
-          .to.contain('}');
+        expect(_file('lib/my-addon/addon/routes/foo/bar.ts')).to.equal(
+          fixture('route/route-nested.ts')
+        );
 
         expect(_file('lib/my-addon/addon/templates/foo/bar.hbs')).to.equal('{{outlet}}');
 
@@ -734,9 +604,9 @@ describe('Blueprint: route', function() {
           "export { default } from 'my-addon/templates/foo/bar';"
         );
 
-        expect(_file('tests/unit/routes/foo/bar-test.ts'))
-          .to.contain("import { moduleFor, test } from 'ember-qunit';")
-          .to.contain("moduleFor('route:foo/bar'");
+        expect(_file('tests/unit/routes/foo/bar-test.ts')).to.equal(
+          fixture('route-test/default-nested.ts')
+        );
       });
     });
   });

--- a/node-tests/fixtures/route-test/default-child.ts
+++ b/node-tests/fixtures/route-test/default-child.ts
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:child', 'Unit | Route | parent/child', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/node-tests/fixtures/route-test/default-nested.ts
+++ b/node-tests/fixtures/route-test/default-nested.ts
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('route:foo/bar', 'Unit | Route | foo/bar', {
+  // Specify the other units that are required for this test.
+  // needs: ['controller:foo']
+});
+
+test('it exists', function(assert) {
+  let route = this.subject();
+  assert.ok(route);
+});

--- a/node-tests/fixtures/route-test/mocha-rfc232.ts
+++ b/node-tests/fixtures/route-test/mocha-rfc232.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Route | foo', function() {
+  setupTest();
+
+  it('exists', function() {
+    let route = this.owner.lookup('route:foo');
+    expect(route).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/route/route-child.ts
+++ b/node-tests/fixtures/route/route-child.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class ParentChild extends Route.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  // normal class body definition here
+}

--- a/node-tests/fixtures/route/route-nested.ts
+++ b/node-tests/fixtures/route/route-nested.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class FooBar extends Route.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  // normal class body definition here
+}

--- a/node-tests/fixtures/route/route.ts
+++ b/node-tests/fixtures/route/route.ts
@@ -1,0 +1,7 @@
+import Route from '@ember/routing/route';
+
+export default class Foo extends Route.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  // normal class body definition here
+}


### PR DESCRIPTION
Adds support for ember-mocha 0.14
Tests are copied from ember.js, after making them based on fixtures through https://github.com/emberjs/ember.js/pull/17196