### PR TITLE
Update acceptance-test blueprints

### DIFF
--- a/blueprints/acceptance-test/index.js
+++ b/blueprints/acceptance-test/index.js
@@ -1,9 +1,9 @@
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 const pathUtil = require('ember-cli-path-utils');
 const stringUtils = require('ember-cli-string-utils');
-const existsSync = require('exists-sync');
 
 const useTestFrameworkDetector = require('../test-framework-detector');
 
@@ -17,7 +17,7 @@ module.exports = useTestFrameworkDetector({
       testFolderRoot = pathUtil.getRelativeParentPath(options.entity.name, -1, false);
     }
 
-    let destroyAppExists = existsSync(
+    let destroyAppExists = fs.existsSync(
       path.join(this.project.root, '/tests/helpers/destroy-app.js')
     );
 
@@ -29,7 +29,7 @@ module.exports = useTestFrameworkDetector({
     return {
       testFolderRoot: testFolderRoot,
       friendlyTestName,
-      destroyAppExists: destroyAppExists,
+      destroyAppExists,
     };
   },
 });

--- a/blueprints/acceptance-test/mocha-rfc-232-files/tests/acceptance/__name__-test.ts
+++ b/blueprints/acceptance-test/mocha-rfc-232-files/tests/acceptance/__name__-test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { visit, currentURL } from '@ember/test-helpers';
+
+describe('<%= friendlyTestName %>', function() {
+  setupApplicationTest();
+
+  it('can visit /<%= dasherizedModuleName %>', async function() {
+    await visit('/<%= dasherizedModuleName %>');
+    expect(currentURL()).to.equal('/<%= dasherizedModuleName %>');
+  });
+});

--- a/node-tests/blueprints/acceptance-test-test.js
+++ b/node-tests/blueprints/acceptance-test-test.js
@@ -17,14 +17,20 @@ describe('Blueprint: acceptance-test', function() {
 
   describe('in app', function() {
     beforeEach(function() {
-      return emberNew().then(() => generateFakePackageManifest('ember-cli-qunit', '4.1.0'));
+      return emberNew();
     });
 
-    it('acceptance-test foo', function() {
-      return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
-        expect(_file('tests/acceptance/foo-test.ts')).to.equal(
-          fixture('acceptance-test/default.ts')
-        );
+    describe('with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
+      });
+
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.ts')).to.equal(
+            fixture('acceptance-test/default.ts')
+          );
+        });
       });
     });
 
@@ -58,32 +64,54 @@ describe('Blueprint: acceptance-test', function() {
         });
       });
     });
+
+    describe('with ember-mocha@0.14.0', function() {
+      beforeEach(function() {
+        modifyPackages([
+          { name: 'ember-cli-qunit', delete: true },
+          { name: 'ember-mocha', dev: true },
+        ]);
+        generateFakePackageManifest('ember-mocha', '0.14.0');
+      });
+
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.ts')).to.equal(
+            fixture('acceptance-test/mocha-rfc268.ts')
+          );
+        });
+      });
+    });
   });
 
   describe('in addon', function() {
     beforeEach(function() {
-      return emberNew({ target: 'addon' }).then(() =>
-        generateFakePackageManifest('ember-cli-qunit', '4.1.0')
-      );
+      return emberNew({ target: 'addon' });
     });
 
-    it('acceptance-test foo', function() {
-      return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
-        expect(_file('tests/acceptance/foo-test.ts')).to.equal(
-          fixture('acceptance-test/addon-default.ts')
-        );
-
-        expect(_file('app/acceptance-tests/foo.ts')).to.not.exist;
+    describe('with ember-cli-qunit@4.1.0', function() {
+      beforeEach(function() {
+        generateFakePackageManifest('ember-cli-qunit', '4.1.0');
       });
-    });
 
-    it('acceptance-test foo/bar', function() {
-      return emberGenerateDestroy(['acceptance-test', 'foo/bar'], _file => {
-        expect(_file('tests/acceptance/foo/bar-test.ts')).to.equal(
-          fixture('acceptance-test/addon-nested.ts')
-        );
+      it('acceptance-test foo', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo'], _file => {
+          expect(_file('tests/acceptance/foo-test.ts')).to.equal(
+            fixture('acceptance-test/addon-default.ts')
+          );
 
-        expect(_file('app/acceptance-tests/foo/bar.ts')).to.not.exist;
+          expect(_file('app/acceptance-tests/foo.ts')).to.not.exist;
+        });
+      });
+
+      it('acceptance-test foo/bar', function() {
+        return emberGenerateDestroy(['acceptance-test', 'foo/bar'], _file => {
+          expect(_file('tests/acceptance/foo/bar-test.ts')).to.equal(
+            fixture('acceptance-test/addon-nested.ts')
+          );
+
+          expect(_file('app/acceptance-tests/foo/bar.ts')).to.not.exist;
+        });
       });
     });
 

--- a/node-tests/fixtures/acceptance-test/mocha-rfc268.ts
+++ b/node-tests/fixtures/acceptance-test/mocha-rfc268.ts
@@ -1,0 +1,13 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { setupApplicationTest } from 'ember-mocha';
+import { visit, currentURL } from '@ember/test-helpers';
+
+describe('Acceptance | foo', function() {
+  setupApplicationTest();
+
+  it('can visit /foo', async function() {
+    await visit('/foo');
+    expect(currentURL()).to.equal('/foo');
+  });
+});


### PR DESCRIPTION
Adds support for ember-mocha 0.14
Test and blueprint's index.js are copied from ember.js