### PR TITLE
Update component and component-test blueprints

### DIFF
--- a/blueprints/component-addon/index.js
+++ b/blueprints/component-addon/index.js
@@ -1,13 +1,12 @@
-/* eslint-env node */
+'use strict';
 
-var stringUtil         = require('ember-cli-string-utils');
-var validComponentName = require('ember-cli-valid-component-name');
-var getPathOption      = require('ember-cli-get-component-path-option');
-var path               = require('path');
-var normalizeEntityName = require('ember-cli-normalize-entity-name');
+const path = require('path');
+const stringUtil = require('ember-cli-string-utils');
+const getPathOption = require('ember-cli-get-component-path-option');
+const normalizeEntityName = require('ember-cli-normalize-entity-name');
 
 module.exports = {
-  description: 'Generates a component. Name must contain a hyphen.',
+  description: 'Generates a component.',
 
   fileMapTokens: function() {
     return {
@@ -28,21 +27,19 @@ module.exports = {
           return path.join('lib', options.inRepoAddon, 'app');
         }
         return 'app';
-      }
+      },
     };
   },
 
   normalizeEntityName: function(entityName) {
-    entityName = normalizeEntityName(entityName);
-
-    return validComponentName(entityName);
+    return normalizeEntityName(entityName);
   },
 
   locals: function(options) {
-    var addonRawName   = options.inRepoAddon ? options.inRepoAddon : options.project.name();
-    var addonName      = stringUtil.dasherize(addonRawName);
-    var fileName       = stringUtil.dasherize(options.entity.name);
-    var importPathName       = [addonName, 'components', fileName].join('/');
+    let addonRawName = options.inRepoAddon ? options.inRepoAddon : options.project.name();
+    let addonName = stringUtil.dasherize(addonRawName);
+    let fileName = stringUtil.dasherize(options.entity.name);
+    let importPathName = [addonName, 'components', fileName].join('/');
 
     if (options.pod) {
       importPathName = [addonName, 'components', fileName, 'component'].join('/');
@@ -50,7 +47,7 @@ module.exports = {
 
     return {
       modulePath: importPathName,
-      path: getPathOption(options)
+      path: getPathOption(options),
     };
-  }
+  },
 };

--- a/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
+++ b/blueprints/component-test/mocha-rfc-232-files/__root__/__testType__/__path__/__test__.ts
@@ -1,0 +1,38 @@
+<% if (testType === 'integration') { %>import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('<%= friendlyTestDescription %>', function() {
+  setupRenderingTest();
+
+  it('renders', async function() {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{<%= componentPathName %>}}`);
+
+    expect(this.element.textContent.trim()).to.equal('');
+
+    // Template block usage:
+    await render(hbs`
+      {{#<%= componentPathName %>}}
+        template block text
+      {{/<%= componentPathName %>}}
+    `);
+
+    expect(this.element.textContent.trim()).to.equal('template block text');
+  });
+});<% } else if (testType === 'unit') { %>import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('<%= friendlyTestDescription %>', function() {
+  setupTest();
+
+  it('exists', function() {
+    let component = this.owner.factoryFor('component:<%= componentPathName %>').create();
+    expect(component).to.be.ok;
+  });
+});<% } %>

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -6,6 +6,7 @@ const pathUtil = require('ember-cli-path-utils');
 const getPathOption = require('ember-cli-get-component-path-option');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
+const EOL = require('os').EOL;
 
 module.exports = {
   description: 'Generates a component.',
@@ -89,8 +90,8 @@ module.exports = {
           'templates/components/' +
           stringUtil.dasherize(options.entity.name);
       }
-      importTemplate = '// @ts-ignore: Ignore import of compiled template\nimport layout from \'' + templatePath + '\';\n';
-      contents = '\n  layout = layout;';
+      importTemplate = '// @ts-ignore: Ignore import of compiled template' + EOL + 'import layout from \'' + templatePath + '\';' + EOL;
+      contents = EOL + '  layout = layout;';
     }
 
     return {

--- a/blueprints/component/index.js
+++ b/blueprints/component/index.js
@@ -3,23 +3,20 @@
 const path = require('path');
 const stringUtil = require('ember-cli-string-utils');
 const pathUtil = require('ember-cli-path-utils');
-const validComponentName = require('ember-cli-valid-component-name');
 const getPathOption = require('ember-cli-get-component-path-option');
 const normalizeEntityName = require('ember-cli-normalize-entity-name');
 const isModuleUnificationProject = require('../module-unification').isModuleUnificationProject;
 
 module.exports = {
-  description: 'Generates a component. Name must contain a hyphen.',
+  description: 'Generates a component.',
 
   availableOptions: [
     {
       name: 'path',
       type: String,
       default: 'components',
-      aliases: [
-        { 'no-path': '' }
-      ]
-    }
+      aliases: [{ 'no-path': '' }],
+    },
   ],
 
   filesPath: function() {
@@ -53,8 +50,9 @@ module.exports = {
         __path__: function(options) {
           if (options.pod) {
             return path.join(options.podPath, options.locals.path, options.dasherizedModuleName);
+          } else {
+            return 'components';
           }
-          return 'components';
         },
         __templatepath__: function(options) {
           if (options.pod) {
@@ -67,28 +65,29 @@ module.exports = {
             return 'template';
           }
           return options.dasherizedModuleName;
-        }
+        },
       };
     }
   },
 
   normalizeEntityName: function(entityName) {
-    entityName = normalizeEntityName(entityName);
-
-    return validComponentName(entityName);
+    return normalizeEntityName(entityName);
   },
 
   locals: function(options) {
     let templatePath = '';
     let importTemplate = '';
     let contents = '';
+
     // if we're in an addon, build import statement
-    if (options.project.isEmberCLIAddon() || options.inRepoAddon && !options.inDummy) {
+    if (options.project.isEmberCLIAddon() || (options.inRepoAddon && !options.inDummy)) {
       if (options.pod) {
         templatePath = './template';
       } else {
-        templatePath = pathUtil.getRelativeParentPath(options.entity.name) +
-          'templates/components/' + stringUtil.dasherize(options.entity.name);
+        templatePath =
+          pathUtil.getRelativeParentPath(options.entity.name) +
+          'templates/components/' +
+          stringUtil.dasherize(options.entity.name);
       }
       importTemplate = '// @ts-ignore: Ignore import of compiled template\nimport layout from \'' + templatePath + '\';\n';
       contents = '\n  layout = layout;';
@@ -97,7 +96,7 @@ module.exports = {
     return {
       importTemplate: importTemplate,
       contents: contents,
-      path: getPathOption(options)
+      path: getPathOption(options),
     };
-  }
+  },
 };

--- a/node-tests/fixtures/component-test/default-template.ts
+++ b/node-tests/fixtures/component-test/default-template.ts
@@ -1,0 +1,24 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('<%= path =%><%= component =%>', 'Integration | Component | <%= component =%>', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`{{<%= path =%><%= component =%>}}`);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#<%= path =%><%= component =%>}}
+      template block text
+    {{/<%= path =%><%= component =%>}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/node-tests/fixtures/component-test/mocha-rfc232-unit.ts
+++ b/node-tests/fixtures/component-test/mocha-rfc232-unit.ts
@@ -1,0 +1,12 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupTest } from 'ember-mocha';
+
+describe('Unit | Component | x-foo', function() {
+  setupTest();
+
+  it('exists', function() {
+    let component = this.owner.factoryFor('component:x-foo').create();
+    expect(component).to.be.ok;
+  });
+});

--- a/node-tests/fixtures/component-test/mocha-rfc232.ts
+++ b/node-tests/fixtures/component-test/mocha-rfc232.ts
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import { setupRenderingTest } from 'ember-mocha';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+
+describe('Integration | Component | x-foo', function() {
+  setupRenderingTest();
+
+  it('renders', async function() {
+    // Set any properties with this.set('myProperty', 'value');
+    // Handle any actions with this.set('myAction', function(val) { ... });
+
+    await render(hbs`{{x-foo}}`);
+
+    expect(this.element.textContent.trim()).to.equal('');
+
+    // Template block usage:
+    await render(hbs`
+      {{#x-foo}}
+        template block text
+      {{/x-foo}}
+    `);
+
+    expect(this.element.textContent.trim()).to.equal('template block text');
+  });
+});

--- a/node-tests/fixtures/component/component-addon-dash-pod.ts
+++ b/node-tests/fixtures/component/component-addon-dash-pod.ts
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+// @ts-ignore: Ignore import of compiled template
+import layout from './template';
+
+export default class XFoo extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  layout = layout;
+  // normal class body definition here
+};

--- a/node-tests/fixtures/component/component-addon-dash.ts
+++ b/node-tests/fixtures/component/component-addon-dash.ts
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+// @ts-ignore: Ignore import of compiled template
+import layout from '../templates/components/x-foo';
+
+export default class XFoo extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  layout = layout;
+  // normal class body definition here
+};

--- a/node-tests/fixtures/component/component-addon-nested-pod.ts
+++ b/node-tests/fixtures/component/component-addon-nested-pod.ts
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+// @ts-ignore: Ignore import of compiled template
+import layout from './template';
+
+export default class FooXFoo extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  layout = layout;
+  // normal class body definition here
+};

--- a/node-tests/fixtures/component/component-addon-nested.ts
+++ b/node-tests/fixtures/component/component-addon-nested.ts
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+// @ts-ignore: Ignore import of compiled template
+import layout from '../../templates/components/foo/x-foo';
+
+export default class FooXFoo extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  layout = layout;
+  // normal class body definition here
+};

--- a/node-tests/fixtures/component/component-addon.ts
+++ b/node-tests/fixtures/component/component-addon.ts
@@ -1,0 +1,10 @@
+import Component from '@ember/component';
+// @ts-ignore: Ignore import of compiled template
+import layout from '../templates/components/foo';
+
+export default class Foo extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  layout = layout;
+  // normal class body definition here
+};

--- a/node-tests/fixtures/component/component-dash.ts
+++ b/node-tests/fixtures/component/component-dash.ts
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+
+export default class XFoo extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  // normal class body definition here
+};

--- a/node-tests/fixtures/component/component-nested.ts
+++ b/node-tests/fixtures/component/component-nested.ts
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+
+export default class FooXFoo extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  // normal class body definition here
+};

--- a/node-tests/fixtures/component/component.ts
+++ b/node-tests/fixtures/component/component.ts
@@ -1,0 +1,7 @@
+import Component from '@ember/component';
+
+export default class Foo extends Component.extend({
+  // anything which *must* be merged to prototype here
+}) {
+  // normal class body definition here
+};

--- a/node-tests/helpers/fixture.js
+++ b/node-tests/helpers/fixture.js
@@ -2,7 +2,16 @@
 
 const path = require('path');
 const file = require('ember-cli-blueprint-test-helpers/chai').file;
+const fs = require('fs');
 
-module.exports = function(filePath) {
-  return file(path.join(__dirname, '../fixtures', filePath));
+module.exports = function(filePath, options) {
+  if (!options) {
+    return file(path.join(__dirname, '../fixtures', filePath));
+  }
+
+  let content = fs.readFileSync(path.join(__dirname, '../fixtures', filePath), { encoding: 'utf-8' });
+  if (options.replace) {
+    content = content.replace(/<%= (\w+) =%>/g, (_match, key) => options.replace[key] || '');
+  }
+  return content;
 };


### PR DESCRIPTION
Adds support for ember-mocha 0.14

Tests are copied from ember.js, after making them based on fixtures through https://github.com/emberjs/ember.js/pull/17198