### PR TITLE
Remove usage of deprecated exists-sync

### DIFF
--- a/lib/utilities/extend-from-application-entity.js
+++ b/lib/utilities/extend-from-application-entity.js
@@ -4,7 +4,7 @@
 var stringUtil = require('ember-cli-string-utils');
 var SilentError = require('silent-error');
 var pathUtil = require('ember-cli-path-utils');
-var existsSync = require('exists-sync');
+var { existsSync } = require('fs');
 var path = require('path');
 
 module.exports = function(type, baseClass, options) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "ember-cli-valid-component-name": "^1.0.0",
     "ember-cli-version-checker": "^5.0.0",
     "ember-router-generator": "^2.0.0",
-    "exists-sync": "^0.1.0",
     "fs-extra": "^8.0.0",
     "inflection": "^1.12.0",
     "silent-error": "^1.1.0"
@@ -44,7 +43,6 @@
     "ember-cli-eslint": "5.1.0",
     "ember-cli-htmlbars": "5.3.1",
     "ember-cli-inject-live-reload": "2.0.2",
-    "ember-qunit": "4.6.0",
     "ember-cli-shims": "1.2.0",
     "ember-cli-sri": "2.1.1",
     "ember-cli-uglify": "3.0.0",
@@ -52,6 +50,7 @@
     "ember-export-application-global": "2.0.1",
     "ember-load-initializers": "2.1.2",
     "ember-maybe-import-regenerator": "0.1.6",
+    "ember-qunit": "4.6.0",
     "ember-resolver": "8.0.2",
     "ember-source": "3.23.0",
     "ember-source-channel-url": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5083,11 +5083,6 @@ exists-sync@0.0.4:
   resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.0.4.tgz#9744c2c428cc03b01060db454d4b12f0ef3c8879"
   integrity sha1-l0TCxCjMA7AQYNtFTUsS8O88iHk=
 
-exists-sync@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/exists-sync/-/exists-sync-0.1.0.tgz#318d545213d2b2a31499e92c35f74c94196a22f7"
-  integrity sha512-qEfFekfBVid4b14FNug/RNY1nv+BADnlzKGHulc+t6ZLqGY4kdHGh1iFha8lnE3sJU/1WzMzKRNxS6EvSakJUg==
-
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"


### PR DESCRIPTION
This fixes warning during `npm install`
```
npm WARN deprecated exists-sync@0.1.0: Please replace with usage of fs.existsSync
```