### PR TITLE
chore(ci): Remove windows from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: install dependencies
         run: yarn install --frozen-lockfile --non-interactive
       - name: linting
-        run: yarn lint
+        run: yarn lint:js
 
   tests:
     name: 'Tests: ${{ matrix.os }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,12 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
-
-      - run: yarn install --frozen-lockfile --non-interactive
-      - run: yarn lint:js
+          node-version: 12.x
+          cache: yarn
+      - name: install dependencies
+        run: yarn install --frozen-lockfile --non-interactive
+      - name: linting
+        run: yarn lint
 
   tests:
     name: 'Tests: ${{ matrix.os }}'
@@ -26,13 +28,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu, macOS, windows]
+        os: [ubuntu, macOS]
 
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
-          node-version: 10.x
+          node-version: 12.x
 
       - run: yarn install --frozen-lockfile --non-interactive
       - run: yarn test


### PR DESCRIPTION
Ember does not test against windows, neither should we.

As discussed here https://github.com/typed-ember/ember-cli-typescript-blueprints/pull/240#issuecomment-1043709635